### PR TITLE
fix devpack:test task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,9 @@ namespace :devpack do
   end
   desc 'Run integration tests'
   task :test do
-    run_integration_tests
+    Bundler.with_clean_env do
+      sh "rspec spec/integration -fd -c"
+    end
   end
   desc 'Creates the devpack .7z package'
   task :package do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -10,7 +10,7 @@ end
 
 module Helpers
   def build_dir
-    File.expand_path(File.join(File.dirname(__FILE__),"..",'build'))
+    File.expand_path(File.join(File.dirname(__FILE__),"..",'out', 'pkg'))
   end
   # sets the environment via set-env.bat before running the command
   # and returns whatever the cmd writes (captures both stdout and stderr)


### PR DESCRIPTION
Port missing spec execution from bill's kitchen (inlined in Rakefile).
Adjust helper.build_dir to point to `.\out\pkg`.